### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/packages/dotted/src/lib/dotted.set.js
+++ b/packages/dotted/src/lib/dotted.set.js
@@ -19,6 +19,9 @@ export const dottedSet = (source, path, value) => {
     
     // get a reference to the deeper layer represented by the path
     const target = tokens.reduce((curr, key) => {
+        if (isPrototypePolluted(key))
+            return {}
+
         return curr[key] = curr[key] || {} 
     }, source)
     
@@ -27,6 +30,8 @@ export const dottedSet = (source, path, value) => {
 
     return source
 }
+
+const isPrototypePolluted = (key) => ['__proto__', 'constructor', 'prototype'].includes(key)
 
 dottedSet.immutable = (source, path, value) =>
     dottedSet(JSON.parse(JSON.stringify(source)), path, value)


### PR DESCRIPTION
### :bar_chart: Metadata *

`@marcopeg/dotted` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40marcopeg%2Fdotted

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```javascript
// poc.js
var {dottedSet} = require("@marcopeg/dotted/lib/dotted.set")
var obj = {}
console.log("Before : " + {}.polluted);
dottedSet(obj, '__proto__.polluted', 'Yes! Its Polluted');
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i @marcopeg/dotted # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/103888846-653e3d80-510b-11eb-8159-e3d3fbff41cd.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
